### PR TITLE
Search engine url setting

### DIFF
--- a/lib/serp.rb
+++ b/lib/serp.rb
@@ -4,10 +4,20 @@ require 'mechanize'
 require 'open-uri'
 
 module Serp
+
+  
+  def self.search_engine=(val)
+    @@search_engine = val
+  end
+
+  def self.search_engine
+    @@search_engine || "http://www.google.com"
+  end
+
   def self.rank(keywords, locale = 'en' , pages = 3)
     results = []
     agent = Mechanize.new
-    page = agent.get("http://www.google.com?hl=#{locale}")
+    page = agent.get("#{search_engine}?hl=#{locale}")
     google_form = page.form('f')
     google_form.q = keywords
     page = agent.submit(google_form, google_form.buttons.first)

--- a/lib/serp.rb
+++ b/lib/serp.rb
@@ -5,13 +5,12 @@ require 'open-uri'
 
 module Serp
 
-  
   def self.search_engine=(val)
     @@search_engine = val
   end
 
   def self.search_engine
-    @@search_engine || "http://www.google.com"
+    @@search_engine ||= "http://www.google.com"
   end
 
   def self.rank(keywords, locale = 'en' , pages = 3)


### PR DESCRIPTION
This enables people to use localised search engine URLs, e.g. <code>http://www.google.co.uk</code>, instead of just <code>http://www.google.com</code>.

This is useful because google.com and google.co.uk give vastly different results. For example:

```
Loading development environment (Rails 3.2.9)
1.9.2-p320 :001 > Serp.rank("R&D Tax Credits", 'en', 2)
 => ["hmrc.gov.uk", "en.wikipedia.org", "revenue.ie", "journalofaccountancy.com", "ato.gov.au", "ausindustry.gov.au", "irs.gov", "cra-arc.gc.ca", "louisianaeconomicdevelopment.com", "scottish-enterprise.com", "gov.mb.ca", "positivelyminnesota.com", "accountingtoday.com", "granttree.co.uk", "businessweek.com", "choosemaryland.org", "revenue.ie", "azcommerce.com", "equinoxinnovations.com", "leyton.com"] 
1.9.2-p320 :002 > Serp.search_engine = "http://www.google.co.uk"
 => "http://www.google.co.uk" 
1.9.2-p320 :003 > Serp.rank("R&D Tax Credits", 'en', 2)
 => ["hmrc.gov.uk", "out-law.com", "scottish-enterprise.com", "granttree.co.uk", "research-and-development-tax-credits.com", "equinoxinnovations.com", "leyton.com", "smeweb.com", "hm-treasury.gov.uk", "startups.co.uk", "rdtaxcredit.co.uk", "ec1capital.com", "rdtaxclaims.co.uk", "jumpstartuk.co.uk", "architecture.com", "managementtoday.co.uk", "hmrc.gov.uk", "bradshawgrice.co.uk", "telegraph.co.uk", "pwc.co.uk"] 
```

Hope this helps someone!
